### PR TITLE
deregister old sales report

### DIFF
--- a/zc_plugins/SalesReport/v4.0.1/Installer/ScriptedInstaller.php
+++ b/zc_plugins/SalesReport/v4.0.1/Installer/ScriptedInstaller.php
@@ -5,7 +5,10 @@ class ScriptedInstaller extends ScriptedInstallBase
 {
     protected function executeInstall()
     {
-        zen_deregister_admin_pages(['statsSalesReport']);
+        zen_deregister_admin_pages([
+                                       'statsSalesReport',
+                                       'stats_sales_report',
+                                   ]);
         zen_register_admin_page(
             'statsSalesReport', 'BOX_REPORTS_SALES_REPORT2', 'FILENAME_STATS_SALES_REPORT2', '', 'reports', 'Y');
     }


### PR DESCRIPTION
the original sales report (of which this is so clearly based on and accredited) used a different admin page key.  

it old seems appropriate to remove that menu item.