### PR TITLE
Internationlization

### DIFF
--- a/zc_plugins/SalesReport/v4.0.2/admin/includes/languages/english/lang.stats_sales_report2.php
+++ b/zc_plugins/SalesReport/v4.0.2/admin/includes/languages/english/lang.stats_sales_report2.php
@@ -82,6 +82,7 @@ $defines = [
     // TIMEFRAME DATE DISPLAY
     // Note:  Other constants moved to the main processing file for v3.2.1.
     //
+    'DATE_FORMAT_TIMEFRAME' => 'd-MMM.-yy',
     'DATE_SPACER' => ' to<br>&nbsp;&nbsp;&nbsp;',
 
     //////////////////////////////////////////////////////////
@@ -130,7 +131,11 @@ $defines = [
     'SEARCH_DATE_THIS_MONTH' => ' This Month (%s)',
     'SEARCH_DATE_LAST_YEAR' => ' Last Year (%s)',
     'SEARCH_DATE_LAST_12_MONTHS' => ' Last 12 Months',
-    'SEARCH_DATE_YTD' => ' YTD (%s)',
+    'SEARCH_DATE_YTD' => ' YTD (%s to %s)',
+    'SEARCH_DATE_YTD_FORMAT_1' => 'MMM. d',
+    'SEARCH_DATE_YTD_FORMAT_2' => 'MMM. d y',
+    'SEARCH_DATE_YTD_FORMAT_M_D' => 'MMM. d',
+    'SEARCH_DATE_YTD_FORMAT_M_Y' => 'MMMM \'\'yy',
     'SEARCH_START_DATE' => 'Start Date',
     'SEARCH_END_DATE' => 'End Date (inclusive)',
     'SEARCH_DATE_FORMAT' => 'mm/dd/yyyy',

--- a/zc_plugins/SalesReport/v4.0.2/admin/stats_sales_report2.php
+++ b/zc_plugins/SalesReport/v4.0.2/admin/stats_sales_report2.php
@@ -41,7 +41,7 @@ $currencies = new currencies();
 // Moved here from the report's language file for v3.2.1 to provide zc156 interoperation,
 // given that that version has changed the loading order of admin language files.
 //
-$time_display = (strtolower(DATE_FORMAT) === 'd/m/y') ? 'n-j-Y' : 'jS-M-y';
+$time_display = DATE_FORMAT_TIMEFRAME;
 zen_define_default('TIME_DISPLAY_DAY', $time_display);
 zen_define_default('TIME_DISPLAY_WEEK', $time_display);
 zen_define_default('TIME_DISPLAY_MONTH', $time_display);
@@ -518,22 +518,22 @@ if ($output_format === 'print') {
                             </tr>
                             <tr>
                                 <td class="smallText" id="td_today">
-                                    <?php echo zen_draw_radio_field('date_preset', 'today', ($date_preset === 'today')) . sprintf(SEARCH_DATE_TODAY, date('M. j', $today_timestamp)); ?>
+                                    <?php echo zen_draw_radio_field('date_preset', 'today', ($date_preset === 'today')) . sprintf(SEARCH_DATE_TODAY, $zcDate->output(SEARCH_DATE_YTD_FORMAT_M_D, $today_timestamp)); ?>
                                 </td>
                             </tr>
                             <tr>
                                 <td class="smallText" id="td_yesterday">
-                                    <?php echo zen_draw_radio_field('date_preset', 'yesterday', ($date_preset === 'yesterday')) . sprintf(SEARCH_DATE_YESTERDAY, date('M. j', strtotime('-1 day', $today_timestamp))); ?>
+                                    <?php echo zen_draw_radio_field('date_preset', 'yesterday', ($date_preset === 'yesterday')) . sprintf(SEARCH_DATE_YESTERDAY, $zcDate->output(SEARCH_DATE_YTD_FORMAT_M_D, strtotime('-1 day', $today_timestamp))); ?>
                                 </td>
                             </tr>
                             <tr>
                                 <td class="smallText" id="td_last_month">
-                                    <?php echo zen_draw_radio_field('date_preset', 'last_month', ($date_preset === 'last_month')) . sprintf(SEARCH_DATE_LAST_MONTH, date("F \'y", strtotime('-1 month', $today_timestamp))); ?>
+                                    <?php echo zen_draw_radio_field('date_preset', 'last_month', ($date_preset === 'last_month')) . sprintf(SEARCH_DATE_LAST_MONTH, $zcDate->output(SEARCH_DATE_YTD_FORMAT_M_Y, strtotime('-1 month', $today_timestamp))); ?>
                                 </td>
                             </tr>
                             <tr>
                                 <td class="smallText" id="td_this_month">
-                                    <?php echo zen_draw_radio_field('date_preset', 'this_month', ($date_preset === 'this_month')) . sprintf(SEARCH_DATE_THIS_MONTH, date("F \'y")); ?>
+                                    <?php echo zen_draw_radio_field('date_preset', 'this_month', ($date_preset === 'this_month')) . sprintf(SEARCH_DATE_THIS_MONTH, $zcDate->output(SEARCH_DATE_YTD_FORMAT_M_Y)); ?>
                                 </td>
                             </tr>
                             <tr>
@@ -548,7 +548,7 @@ if ($output_format === 'print') {
                             </tr>
                             <tr>
                                 <td class="smallText" id="td_YTD">
-                                    <?php echo zen_draw_radio_field('date_preset', 'YTD', ($date_preset === 'YTD' || !empty($date_custom))) . sprintf(SEARCH_DATE_YTD, 'Jan 1 to ' . date('M. j Y', $today_timestamp)); ?>
+                                    <?php echo zen_draw_radio_field('date_preset', 'YTD', ($date_preset === 'YTD' || !empty($date_custom))) . sprintf(SEARCH_DATE_YTD, $zcDate->output(SEARCH_DATE_YTD_FORMAT_1, mktime(0,0,0,1,1,date('Y'))), $zcDate->output(SEARCH_DATE_YTD_FORMAT_2)); ?>
                                 </td>
                             </tr>
                         </table>
@@ -901,16 +901,16 @@ if ($output_format === 'print' || $output_format === 'display') {
         // generate the timeframe date display
         switch ($sr->timeframe_group) {
             case 'day':
-                $time_display = date(TIME_DISPLAY_DAY, $timeframe['sd']);
+                $time_display = $zcDate->output(TIME_DISPLAY_DAY, $timeframe['sd']);
                 break;
             case 'week':
-                $time_display = date(TIME_DISPLAY_WEEK, $timeframe['sd']) . DATE_SPACER . date(TIME_DISPLAY_WEEK, $timeframe['ed']);
+                $time_display = $zcDate->output(TIME_DISPLAY_WEEK, $timeframe['sd']) . DATE_SPACER . $zcDate->output(TIME_DISPLAY_WEEK, $timeframe['ed']);
                 break;
             case 'month':
-                $time_display = date(TIME_DISPLAY_MONTH, $timeframe['sd']) . DATE_SPACER . date(TIME_DISPLAY_MONTH, $timeframe['ed']);
+                $time_display = $zcDate->output(TIME_DISPLAY_MONTH, $timeframe['sd']) . DATE_SPACER . $zcDate->output(TIME_DISPLAY_MONTH, $timeframe['ed']);
                 break;
             case 'year':
-                $time_display = date(TIME_DISPLAY_YEAR, $timeframe['sd']) . DATE_SPACER . date(TIME_DISPLAY_YEAR, $timeframe['ed']);
+                $time_display = $zcDate->output(TIME_DISPLAY_YEAR, $timeframe['sd']) . DATE_SPACER . $zcDate->output(TIME_DISPLAY_YEAR, $timeframe['ed']);
                 break;
         }
 


### PR DESCRIPTION
Few changes to use `$zcDate->output` method instead of PHP `date()` function.
With few new constants, dates display can be customized for any language format.
Here are some screenshots with French and Japanese:
![Capture d'écran 2024-11-07 232115](https://github.com/user-attachments/assets/2732f44c-ffe0-44e5-aca9-7db482c2d52d)
![Capture d'écran 2024-11-07 232139](https://github.com/user-attachments/assets/45094a2f-e65e-4e92-a959-973c7c637fd0)
![Capture d'écran 2024-11-07 233737](https://github.com/user-attachments/assets/e295897b-4abd-4b2a-a6ea-e1c5c5f79e6e)
![Capture d'écran 2024-11-07 234034](https://github.com/user-attachments/assets/0db27248-5a9a-4794-aa72-f137321d388e)

Only the ordinal suffixes (-th...) in English can not be displayed like before, as the `IntlDateFormatter` class does not have a method for that.
It has been made like this on purpose. In correct English, one should not write an ordinal suffix in a date. It seems this rule is not always respected anyway... But to keep a good accessibility (due to automatic reading software), it should be.