### PR TITLE
Correct date formats used for datepicker and display.

### DIFF
--- a/zc_plugins/SalesReport/v4.0.3/admin/includes/classes/sales_report2.php
+++ b/zc_plugins/SalesReport/v4.0.3/admin/includes/classes/sales_report2.php
@@ -1097,20 +1097,20 @@ ORDER BY orders_id, orders_status_id, date_added) '. PHP_EOL;
             // format the dates
             switch ($this->timeframe_group) {
                 case 'day':
-                    $start_date = date(TIME_DISPLAY_DAY, $timeframe['sd']);
-                    $end_date = date(TIME_DISPLAY_DAY, $timeframe['ed']);
+                    $start_date = date(DATE_FORMAT, $timeframe['sd']);
+                    $end_date = date(DATE_FORMAT, $timeframe['ed']);
                     break;
                 case 'week':
-                    $start_date = date(TIME_DISPLAY_WEEK, $timeframe['sd']);
-                    $end_date = date(TIME_DISPLAY_WEEK, $timeframe['ed']);
+                    $start_date = date(DATE_FORMAT, $timeframe['sd']);
+                    $end_date = date(DATE_FORMAT, $timeframe['ed']);
                     break;
                 case 'month':
-                    $start_date = date(TIME_DISPLAY_MONTH, $timeframe['sd']);
-                    $end_date = date(TIME_DISPLAY_MONTH, $timeframe['ed']);
+                    $start_date = date(DATE_FORMAT, $timeframe['sd']);
+                    $end_date = date(DATE_FORMAT, $timeframe['ed']);
                     break;
                 case 'year':
-                    $start_date = date(TIME_DISPLAY_YEAR, $timeframe['sd']);
-                    $end_date = date(TIME_DISPLAY_YEAR, $timeframe['ed']);
+                    $start_date = date(DATE_FORMAT, $timeframe['sd']);
+                    $end_date = date(DATE_FORMAT, $timeframe['ed']);
                     break;
             }
             switch ($this->detail_level) {
@@ -1260,5 +1260,19 @@ ORDER BY orders_id, orders_status_id, date_added) '. PHP_EOL;
     protected function outputCsvLine($line)
     {
         echo implode(CSV_SEPARATOR, $line) . CSV_NEWLINE;
+    }
+
+    public static function zen_date_format_fordatepicker()
+    {
+        $date = DATE_FORMAT;
+        $date = str_replace('m', 'mm', $date);
+        $date = str_replace('d', 'dd', $date);
+        $date = str_replace('Y', 'yy', $date);
+        return $date;
+    }
+
+    public static function zen_date_to_datepicker_format_full()
+    {
+        return str_replace("YY", "YYYY", strtoupper(self::zen_date_format_fordatepicker()));
     }
 }

--- a/zc_plugins/SalesReport/v4.0.3/admin/stats_sales_report2.php
+++ b/zc_plugins/SalesReport/v4.0.3/admin/stats_sales_report2.php
@@ -179,7 +179,7 @@ $product_sorts_array = [
 $date_preset = (!empty($_GET['date_preset'])) ? $_GET['date_preset'] : 'YTD';
 $date_custom = (isset($_GET['date_custom']) && $_GET['date_custom'] === '1') ? '1' : '0';
 $today_timestamp = strtotime('today midnight');
-$datepicker_format = zen_datepicker_format_fordate();
+$datepicker_format = DATE_FORMAT;
 if ($date_custom === '1') {
     // defaults to beginning of the month when not set
     $start_date = (!empty($_GET['start_date'])) ? $_GET['start_date'] : date($datepicker_format, strtotime('first day of this month', $today_timestamp));
@@ -222,9 +222,11 @@ $dt = DateTime::createFromFormat($datepicker_format, $start_date);
 if ($dt === false) {
     $dt = DateTime::createFromFormat($datepicker_format, date($datepicker_format, strtotime('first day of this month', $today_timestamp)));
 }
+$dt_start = $dt->format('Y-m-d'); // SQL format
 
 $dt = DateTime::createFromFormat($datepicker_format, $end_date);
 $end_date = ($dt === false) ? $start_date : $end_date;
+$dt_end = ($dt === false) ? $dt_start : $dt->format('Y-m-d'); // SQL format
 
 $date_target = (isset($_GET['date_target']) && in_array($_GET['date_target'], ['purchased', 'status'])) ? $_GET['date_target'] : 'purchased';
 if ($date_target === 'status') {
@@ -374,8 +376,8 @@ if ($output_format === false) {
         $sr_parms = [
             'timeframe' => $timeframe,
             'timeframe_sort' => ($timeframe_sort === SEARCH_TIMEFRAME_SORT_DESC) ? 'desc' : 'asc',
-            'start_date' => $start_date,
-            'end_date' => $end_date,
+            'start_date' => $dt_start,
+            'end_date' => $dt_end,
             'date_target' => $date_target,
             'date_status' => $date_status,
             'payment_method' => $payment_method,
@@ -566,7 +568,7 @@ if ($output_format === 'print') {
                                     <div class="date">
                                         <?= zen_draw_input_field('start_date', $start_date, 'id="start-date" autocomplete="off"') ?>
                                     </div>
-                                    <span class="help-block errorText">(<?= zen_datepicker_format_full() ?>)</span>
+                                    <span class="help-block errorText">(<?= sales_report2::zen_date_to_datepicker_format_full() ?>)</span>
                                 </td>
                             </tr>
                             <tr>
@@ -575,7 +577,7 @@ if ($output_format === 'print') {
                                     <div class="date">
                                         <?= zen_draw_input_field('end_date', $end_date, 'id="end-date" autocomplete="off"') ?>
                                     </div>
-                                    <span class="help-block errorText">(<?= zen_datepicker_format_full() ?>)</span>
+                                    <span class="help-block errorText">(<?= sales_report2::zen_date_to_datepicker_format_full() ?>)</span>
                                 </td>
                             </tr>
                         </table></td>
@@ -1794,8 +1796,12 @@ if ($output_format !== 'print') {
 ?>
     <script>
     $(function() {
-        $('#start-date').datepicker();
-        $('#end-date').datepicker();
+        $('#start-date').datepicker({
+            dateFormat: '<?= sales_report2::zen_date_format_fordatepicker(); ?>',
+        });
+        $('#end-date').datepicker({
+                    dateFormat: '<?= sales_report2::zen_date_format_fordatepicker(); ?>',
+        });
     });
     </script>
 <?php

--- a/zc_plugins/SalesReport/v4.0.3/admin/stats_sales_report2.php
+++ b/zc_plugins/SalesReport/v4.0.3/admin/stats_sales_report2.php
@@ -179,52 +179,51 @@ $product_sorts_array = [
 $date_preset = (!empty($_GET['date_preset'])) ? $_GET['date_preset'] : 'YTD';
 $date_custom = (isset($_GET['date_custom']) && $_GET['date_custom'] === '1') ? '1' : '0';
 $today_timestamp = strtotime('today midnight');
-$datepicker_format = DATE_FORMAT;
 if ($date_custom === '1') {
     // defaults to beginning of the month when not set
-    $start_date = (!empty($_GET['start_date'])) ? $_GET['start_date'] : date($datepicker_format, strtotime('first day of this month', $today_timestamp));
+    $start_date = (!empty($_GET['start_date'])) ? $_GET['start_date'] : date(DATE_FORMAT, strtotime('first day of this month', $today_timestamp));
     $end_date = (!empty($_GET['end_date'])) ? $_GET['end_date'] : $start_date;
 } else {
     switch ($date_preset) {
         case 'today':
-            $start_date = date($datepicker_format, $today_timestamp);
+            $start_date = date(DATE_FORMAT, $today_timestamp);
             $end_date = $start_date;
             break;
         case 'yesterday':
-            $start_date = date($datepicker_format, strtotime('yesterday', $today_timestamp));
+            $start_date = date(DATE_FORMAT, strtotime('yesterday', $today_timestamp));
             $end_date = $start_date;
             break;
         case 'last_month':
-            $start_date = date($datepicker_format, strtotime('first day of last month', $today_timestamp));
-            $end_date = date($datepicker_format, strtotime('last day of last month', $today_timestamp));
+            $start_date = date(DATE_FORMAT, strtotime('first day of last month', $today_timestamp));
+            $end_date = date(DATE_FORMAT, strtotime('last day of last month', $today_timestamp));
             break;
         case 'this_month':
-            $start_date = date($datepicker_format, strtotime('first day of this month', $today_timestamp));
-            $end_date = date($datepicker_format, $today_timestamp);
+            $start_date = date(DATE_FORMAT, strtotime('first day of this month', $today_timestamp));
+            $end_date = date(DATE_FORMAT, $today_timestamp);
             break;
         case 'last_year':
-            $start_date = date($datepicker_format, strtotime('last year January 1st', $today_timestamp));
-            $end_date = date($datepicker_format, strtotime('last year December 31st', $today_timestamp));
+            $start_date = date(DATE_FORMAT, strtotime('last year January 1st', $today_timestamp));
+            $end_date = date(DATE_FORMAT, strtotime('last year December 31st', $today_timestamp));
             break;
         case 'last_12_months':
-            $start_date = date($datepicker_format, strtotime('1 year ago', $today_timestamp));
-            $end_date = date($datepicker_format, $today_timestamp);
+            $start_date = date(DATE_FORMAT, strtotime('1 year ago', $today_timestamp));
+            $end_date = date(DATE_FORMAT, $today_timestamp);
             break;
         default:
             $_GET['date_preset'] = 'YTD';
-            $start_date = date($datepicker_format, strtotime('first day of January this year', $today_timestamp));
-            $end_date = date($datepicker_format, $today_timestamp);
+            $start_date = date(DATE_FORMAT, strtotime('first day of January this year', $today_timestamp));
+            $end_date = date(DATE_FORMAT, $today_timestamp);
             break;
     }
 }
 
-$dt = DateTime::createFromFormat($datepicker_format, $start_date);
+$dt = DateTime::createFromFormat(DATE_FORMAT, $start_date);
 if ($dt === false) {
-    $dt = DateTime::createFromFormat($datepicker_format, date($datepicker_format, strtotime('first day of this month', $today_timestamp)));
+    $dt = DateTime::createFromFormat(DATE_FORMAT, date(DATE_FORMAT, strtotime('first day of this month', $today_timestamp)));
 }
 $dt_start = $dt->format('Y-m-d'); // SQL format
 
-$dt = DateTime::createFromFormat($datepicker_format, $end_date);
+$dt = DateTime::createFromFormat(DATE_FORMAT, $end_date);
 $end_date = ($dt === false) ? $start_date : $end_date;
 $dt_end = ($dt === false) ? $dt_start : $dt->format('Y-m-d'); // SQL format
 

--- a/zc_plugins/SalesReport/v4.0.3/admin/stats_sales_report2.php
+++ b/zc_plugins/SalesReport/v4.0.3/admin/stats_sales_report2.php
@@ -1796,10 +1796,10 @@ if ($output_format !== 'print') {
     <script>
     $(function() {
         $('#start-date').datepicker({
-            dateFormat: '<?= sales_report2::zen_date_format_fordatepicker(); ?>',
+            dateFormat: '<?= sales_report2::zen_date_format_fordatepicker() ?>',
         });
         $('#end-date').datepicker({
-                    dateFormat: '<?= sales_report2::zen_date_format_fordatepicker(); ?>',
+            dateFormat: '<?= sales_report2::zen_date_format_fordatepicker() ?>',
         });
     });
     </script>


### PR DESCRIPTION
Ref #58 
Although related to forum thread [here](https://www.zen-cart.com/showthread.php/44669-Sales-report-2-0/page88).
The same date format was used for displaying dates in form, for the date picker and for the class 'sales_report2' (which actually needs a Y-m-d format). This PR provides the right date format depending on where it is used.
